### PR TITLE
fix: bun set up fail due to install step error

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,13 @@
 # [Choice] Debian OS version: bullseye, buster
 FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/base:dev-bullseye
 
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
 ENV BUN_INSTALL=/bun
 RUN sudo mkdir -p ${BUN_INSTALL} \
-    && curl -fsSL https://bun.sh/install | sh \
+    && curl -fsSL https://bun.sh/install | bash \
     && chown -R ${USERNAME} /bun
 
 ENV PATH=${BUN_INSTALL}/bin:${PATH}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,9 +2,9 @@
 FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/base:dev-bullseye
 
 ENV BUN_INSTALL=/bun
-RUN mkdir -p /bun \
+RUN sudo mkdir -p ${BUN_INSTALL} \
     && curl -fsSL https://bun.sh/install | sh \
-    && chown -R vscode /bun
+    && chown -R ${USERNAME} /bun
 
 ENV PATH=${BUN_INSTALL}/bin:${PATH}
 


### PR DESCRIPTION
this changeset is to fix the codespaces container creation due to bun setup step failure

- use `sudo` when creating `bun` folder
- use `bash` for download and install bun from the website
- create user-related variables
- use bun path variable
- use user variables