### PR TITLE
migrate: replace bun docker image with bun devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Bun",
   // See complete list https://hub.docker.com/r/oven/bun
-  "image": "oven/bun",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [
     // Http
@@ -18,7 +18,8 @@
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
       "moby": false,
       "dockerDashComposeVersion": "v2"
-    }
+    },
+    "ghcr.io/alertbox/devcontainer-features/bun:2": {},
   },
   "containerEnv": {},
   "remoteEnv": {},
@@ -28,8 +29,6 @@
     "vscode": {
       // Add the IDs of extensions you want installed when the container is created.
       "extensions": [
-        // JavaScript
-        "oven.bun-vscode",
         // TypeScript
         "bierner.lit-html",
         "better-ts-errors.better-ts-errors",
@@ -50,7 +49,6 @@
       "settings": {
         "terminal.integrated.defaultProfile.linux": "zsh",
         "debug.internalConsoleOptions": "neverOpen",
-        "editor.formatOnPaste": true,
         "editor.guides.bracketPairs": "active",
         "scm.defaultViewMode": "tree",
         "diffEditor.diffAlgorithm": "advanced",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "humao.rest-client",
     // Remote Containers
-    "ms-azuretools.vscode-docker",
+    "ms-azuretools.vscode-containers",
     "ms-vscode-remote.remote-containers",
     "ms-vscode.remote-repositories",
     // Configurations

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 Start a dev container and get to developing a [variety of JavaScript-based (or TypeScript) web apps and services][bun-guides].
 
-> Originally, this dev container was created to have an isolated development environment to install the pre-release versions on Windows. See [Known Issues](#known-issues) to learn more.
+> [!Note]
+>
+> Originally, this dev container was created to have an isolated development environment to install the pre-release versions on WSL. See [Known Issues](#known-issues) to learn more.
 
 [bun-guides]: https://bun.sh/guides
 
@@ -18,21 +20,15 @@ You can also run this repo locally by following these repetitive steps:
 1. You want to ensure the repo is cloned to your local machine, and
 2. Open it in VS Code.
 
+See [Bun Releases][bun-releases] for other variations that suites your need.
 
-
->  See [Bun Docker Images][bun-docker-images] for other variations that suites your hardware.
-
-[bun-docker-images]: https://hub.docker.com/r/oven/bun
-
-
+[bun-releases]: https://github.com/oven-sh/bun/releases
 
 ## Troubleshooting
 
 If you have any technical problems with dev containers, you are better off asking their [Discord Channel][discord-channel] directly, since you'll end up getting a much faster response back that way.
 
 [discord-channel]: https://discord.com/invite/CXdq2DP29u
-
-
 
 ### Known Issues
 
@@ -48,10 +44,8 @@ Have a suggestion or a bug fix? Just open a pull request or an issue. Include cl
 
 [bun-repo]: https://github.com/oven-sh/bun?tab=readme-ov-file#readme
 
-
-
 ## License
 
-Copyright &copy; Alertbox, Inc. (@alertbox). All rights reserved.
+Copyright (c) Alertbox, Inc. (@alertbox). All rights reserved.
 
 The source code is license under the [MIT license](#MIT-1-ov-file).


### PR DESCRIPTION
this changeset is to try bun as a devcontainer feature.

- replace devcontainer image from `base:ubuntu` image
- add bun devcontainer feature from @alertbox/devcontainer-features
- reword repo documentation